### PR TITLE
Add "game over" state

### DIFF
--- a/server/ServerHandle.cs
+++ b/server/ServerHandle.cs
@@ -59,7 +59,8 @@ namespace Sabotage {
             int otherPlayer;
             if (fromClient == 1) otherPlayer = 2;
             else otherPlayer = 1;
-            ServerSend.ConfirmAllServicesSunk(otherPlayer);
+            ServerSend.ConfirmAllServicesSunk(otherPlayer, true);
+            ServerSend.ConfirmAllServicesSunk(fromClient, false);
         }
     }
 }

--- a/server/ServerSend.cs
+++ b/server/ServerSend.cs
@@ -88,9 +88,10 @@ namespace Sabotage {
             }
         }
 
-        public static void ConfirmAllServicesSunk(int toClient) {
+        public static void ConfirmAllServicesSunk(int client, bool winner) {
             using (Packet packet = new Packet((int)ServerPackets.allServicesSunk)) {
-                SendTCPData(toClient, packet);
+                packet.Write(winner);
+                SendTCPData(client, packet);
             }
         }
     }

--- a/view/ClientHandle.cs
+++ b/view/ClientHandle.cs
@@ -74,6 +74,9 @@ namespace Sabotage {
 
         public static void ConfirmAllServicesSunk(Packet packet) {
             Console.WriteLine("We sunk all their services");
+            bool winner = packet.ReadBool();
+            Action gameOver = delegate() { MainWindow.GameOver(winner); };
+            Dispatcher.UIThread.InvokeAsync(gameOver);
         }
     }
 }

--- a/view/GameLogic.cs
+++ b/view/GameLogic.cs
@@ -118,7 +118,7 @@ namespace Sabotage {
 
             PlaceService("Notifications", 2, true);
 
-            PlaceService("Backoffice Proxy", 2, true);
+            PlaceService("BoP", 2, true);
             
         }
 

--- a/view/Views/MainWindow.axaml
+++ b/view/Views/MainWindow.axaml
@@ -28,6 +28,10 @@
             </ExperimentalAcrylicBorder.Material>
         </ExperimentalAcrylicBorder>
         <Panel Margin="25">
+            <Panel x:Name="gameOverHeader" IsVisible="False" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock TextAlignment="Center" FontFamily="/Assets/Fonts/BasicallyAMono-Bold.ttf#" FontSize="48">GAME OVER</TextBlock>
+                <TextBlock TextAlignment="Center" x:Name="gameOverMessage" Margin="0, 75, 0, 0"></TextBlock>
+            </Panel>
             <Panel x:Name="gamePlayHeader" IsVisible="False">
                 <Image Source="/Assets/Images/sabotage.png" Width="200" HorizontalAlignment="Center" VerticalAlignment="Top" />
                 <Grid VerticalAlignment="Top" HorizontalAlignment="Right" ShowGridLines="False" Height="50" Width="50" Margin="0, 10, 0, 0">

--- a/view/Views/MainWindow.axaml.cs
+++ b/view/Views/MainWindow.axaml.cs
@@ -22,6 +22,8 @@ namespace Sabotage.Views
         private static Panel splashHdr;
         private static Panel gamePlayHdr;
         private static TextBlock turnTracker;
+        private static TextBlock gameOverText;
+        private static Panel gameOverHdr;
         
         public MainWindow()
         {
@@ -33,6 +35,8 @@ namespace Sabotage.Views
             splashHdr = this.GetControl<Panel>("splashHeader");
             gamePlayHdr = this.GetControl<Panel>("gamePlayHeader");
             turnTracker = this.GetControl<TextBlock>("turnTrackerBlock");
+            gameOverText = this.GetControl<TextBlock>("gameOverMessage");
+            gameOverHdr = this.GetControl<Panel>("gameOverHeader");
 
             foreach(Button button in this.GetControl<Grid>("grid").GetVisualChildren()) {
                 buttons.Add(button);
@@ -101,6 +105,16 @@ namespace Sabotage.Views
         public static void ServiceDown(string serviceName) {
             turnTracker.Text = $"You took the {serviceName} service down!!!";
             turnTracker.Background = new SolidColorBrush(new Color(255, 190, 0, 0));
+        }
+
+        public static void GameOver(bool winner) {
+            if (winner) gameOverText.Text = "You win!";
+            else gameOverText.Text = "You lose!";
+
+            gameOverHdr.IsVisible = true;
+            gamePlayHdr.IsVisible = false;
+            board.IsVisible = false;
+            turnTracker.IsVisible = false;
         }
     }
 }


### PR DESCRIPTION
When a player has brought down all services of their opponent, we'll render a game over message, with a win/lose annotation.


https://user-images.githubusercontent.com/1641557/192026977-4f8de9fb-9ab5-465a-83e1-46f543c9de63.mov

